### PR TITLE
[Tizen.Log] Remove Substring function

### DIFF
--- a/src/Tizen.Log/Tizen/Log.cs
+++ b/src/Tizen.Log/Tizen/Log.cs
@@ -57,21 +57,21 @@ namespace Tizen
                     return;
                 }
 
-                int index = file.LastIndexOfAny(sep);
-                string filename = file.Substring(index + 1);
+                int index = file.LastIndexOfAny(sep) + 1;
+                int filenameLength = file.Length - index;
 
-                int filenameByteLength = Encoding.UTF8.GetMaxByteCount(filename.Length);
+                int filenameByteLength = Encoding.UTF8.GetMaxByteCount(filenameLength);
                 Span<byte> filenameByte = filenameByteLength < 1024 ? stackalloc byte[filenameByteLength + 1] : new byte[filenameByteLength + 1];
 
                 int funcByteLength = Encoding.UTF8.GetMaxByteCount(func.Length);
                 Span<byte> funcByte = funcByteLength < 1024 ? stackalloc byte[funcByteLength + 1] : new byte[funcByteLength + 1];
 
-                fixed (char* pFilenameChar = filename)
+                fixed (char* pFilenameChar = file)
                 fixed (char* pFuncChar = func)
                 fixed (byte* pFilenameByte = &MemoryMarshal.GetReference(filenameByte))
                 fixed (byte* pFuncByte = &MemoryMarshal.GetReference(funcByte))
                 {
-                    len = Encoding.UTF8.GetBytes(pFilenameChar, filename.Length, pFilenameByte, filenameByteLength);
+                    len = Encoding.UTF8.GetBytes(pFilenameChar + index, filenameLength, pFilenameByte, filenameByteLength);
                     pFilenameByte[len] = 0;
                     len = Encoding.UTF8.GetBytes(pFuncChar, func.Length, pFuncByte, funcByteLength);
                     pFuncByte[len] = 0;


### PR DESCRIPTION
To cut filename from whole filepath, Print function uses Substring function. Also, filename string is newly created.
To avoid newly create memory which can be garbage collecting target, Substring function is removed.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
